### PR TITLE
Avoid to add empty rtp. Unbundle report error when adding empty rtp

### DIFF
--- a/plugin/extra.vim
+++ b/plugin/extra.vim
@@ -2,9 +2,22 @@ if $GOPATH == ''
   finish
 endif
 
-let s:gopath = substitute($GOPATH, (has('win32') || has('win64')) ? ';' : ':', ',', 'g')
-exe "set rtp+="
-\       . globpath(s:gopath, "src/github.com/nsf/gocode/vim")
-\ . ',' . globpath(s:gopath, "src/github.com/golang/lint/misc/vim")
-\ . ',' . globpath(s:gopath, "src/code.google.com/p/go.tools/cmd/misc/vim")
-unlet s:gopath
+let s:extras = [
+\"github.com/nsf/gocode/vim",
+\"github.com/golang/lint/misc/vim",
+\"code.google.com/p/go.tools/cmd/misc/vim",
+\]
+
+function! s:install_extras()
+  let gopath = substitute($GOPATH, (has('win32') || has('win64')) ? ';' : ':', ',', 'g')
+  let gopath = join(filter(map(s:extras, "
+  \  globpath(gopath, 'src/' . v:val)
+  \"), 'len(v:val)>0'), ',')
+  if len(gopath) > 0
+    exec 'set rtp+=' . gopath
+  endif
+endfunction
+
+call s:install_extras()
+delfunction s:install_extras
+unlet s:extras


### PR DESCRIPTION
空の rtp (`/foo,,` の様な)が足されない様にしました。
