### PR TITLE
Fix error when GOPATH contains multiple paths

### DIFF
--- a/plugin/extra.vim
+++ b/plugin/extra.vim
@@ -11,7 +11,7 @@ let s:extras = [
 function! s:install_extras()
   let gopath = substitute($GOPATH, (has('win32') || has('win64')) ? ';' : ':', ',', 'g')
   let gopath = join(filter(map(s:extras, "
-  \  globpath(gopath, 'src/' . v:val)
+  \  join(globpath(gopath, 'src/' . v:val, 0, 1), ',')
   \"), 'len(v:val)>0'), ',')
   if len(gopath) > 0
     exec 'set rtp+=' . gopath


### PR DESCRIPTION
globpath が改行で連結してくれるのでエラーになっていた