### PR TITLE
Improve 'no documentation' detection in :Godoc

### DIFF
--- a/plugin/godoc.vim
+++ b/plugin/godoc.vim
@@ -65,6 +65,14 @@ function! s:GodocView()
   au BufHidden <buffer> call let <SID>buf_nr = -1
 endfunction
 
+function! s:GodocNotFound(content)
+  if !len(a:content)
+    return 1
+  endif
+
+  return a:content =~# '^.*: no such file or directory\n'
+endfunction
+
 function! s:GodocWord(word)
   if !executable('godoc')
     echohl WarningMsg
@@ -78,7 +86,7 @@ function! s:GodocWord(word)
   if v:shell_error || !len(content)
     if len(s:last_word)
       silent! let content = system('godoc ' . s:last_word.'/'.word)
-      if v:shell_error || !len(content)
+      if v:shell_error || s:GodocNotFound(content)
         echo 'No documentation found for "' . word . '".'
         return 0
       endif


### PR DESCRIPTION
`:Godoc foobar` のように存在しないドキュメントを開こうとすると

```
2015/04/21 03:58:02 open /usr/local/Cellar/go/1.4.2/libexec/src/foobar: no such file or directory
```

のように `godoc` コマンドの結果がそのまま別ウィンドウに出てしまっていました．どうやら `v:shell_error` は `0` になってしまうようなので，コマンドの出力結果を見て判断するようにしてみました．

これによって，`:Godoc foobar` のようにしても

```
No documentation found for "foobar".
```

のようにメッセージが echo されるだけで新しいウィンドウが開かれることはなくなります．